### PR TITLE
fix: 19951567 Entity Clone Paragraph Parent ID Bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -256,6 +256,9 @@
             },
             "drupal/webform": {
                 "By default, do not save submissions.": "patches/disable-results-by-default.patch"
+            },
+            "drupal/entity_clone": {
+                "Parent ID of original paragraph assigned to cloned node id.": "https://www.drupal.org/files/issues/2020-12-11/entity_clone-corrupted-paragraph-cloning-3060223-35.patch"
             }
         },
         "installer-types": [


### PR DESCRIPTION
When a node with paragraphs is cloned, the original paragraph parent id
would be set to the new cloned paragraph, preventing it from rendeing
due to access issues.

This commit applies a patch to resolve the issue.
https://www.drupal.org/project/entity_clone/issues/3060223