### PR TITLE
SRL-445: Minor patch to linkit module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ node_modules
 .favorites.json
 *.code-workspace
 .DS_Store
+.lando.local.yml
 
 # Ignore .env files as they are personal
 /.env

--- a/composer.json
+++ b/composer.json
@@ -268,6 +268,9 @@
             },
             "drupal/svg_image_field": {
                 "Fix previews": "https://www.drupal.org/files/issues/2019-05-06/svg_image_field-zero-width-preview-3053018.patch"
+            },
+            "drupal/linkit": {
+                "Linkit: invalid condition operator": "patches/2769191-invalid-condition-operator-config-entities-8.4.patch"
             }
         },
         "installer-types": [

--- a/config/config-default/config_split.config_split.local.yml
+++ b/config/config-default/config_split.config_split.local.yml
@@ -8,7 +8,8 @@ id: local
 label: Local
 description: 'Local development environments.'
 folder: ../config/config-local
-module: {  }
+module:
+  devel: 0
 theme: {  }
 blacklist: {  }
 graylist:

--- a/patches/2769191-invalid-condition-operator-config-entities-8.4.patch
+++ b/patches/2769191-invalid-condition-operator-config-entities-8.4.patch
@@ -1,0 +1,12 @@
+diff --git a/src/Plugin/Linkit/Matcher/EntityMatcher.php b/src/Plugin/Linkit/Matcher/EntityMatcher.php
+index 3383820..63c55ea 100644
+--- a/src/Plugin/Linkit/Matcher/EntityMatcher.php
++++ b/src/Plugin/Linkit/Matcher/EntityMatcher.php
+@@ -262,7 +262,7 @@ class EntityMatcher extends ConfigurableMatcherBase {
+     $label_key = $entity_type->getKey('label');
+
+     if ($label_key) {
+-      $query->condition($label_key, '%' . $match . '%', 'LIKE');
++      $query->condition($label_key, $match, 'CONTAINS');
+       $query->sort($label_key, 'ASC');
+     }


### PR DESCRIPTION
Linkit EntityMatcher used LIKE in a query condition which is not supported.
Patch updates the condition to use CONTAINS.
There was some discussion on the 8.5 fix about config entities vs content
entities and a conditional to check the entity class and use LIKE only for
content entities, but that doesn't seem to be supported. I'm not aware of
any reason not to use CONTAINS on all queries, so I have not ported the
8.5 patch to our 8.4 module.