### PR TITLE
bugfix srl-859 hide the court house image under mobile view

### DIFF
--- a/web/themes/custom/atrium/atrium.libraries.yml
+++ b/web/themes/custom/atrium/atrium.libraries.yml
@@ -57,3 +57,8 @@ iframe-resizer-client:
 chatbot-banner:
   js:
     assets/js/chatbot-banner.js: {}
+
+switchboard_overrides:
+  css:
+    theme:
+      css/switchboard-overrides.css: {}

--- a/web/themes/custom/atrium/css/switchboard-overrides.css
+++ b/web/themes/custom/atrium/css/switchboard-overrides.css
@@ -1,6 +1,6 @@
+/* Hide only the switchboard body when an image exists */
 @media (max-width: 800px) {
-  .jcc-switchboard__body {
+  .paragraph-switchboard-wrapper.has-image .jcc-switchboard__body {
     display: none !important;
   }
 }
-

--- a/web/themes/custom/atrium/css/switchboard-overrides.css
+++ b/web/themes/custom/atrium/css/switchboard-overrides.css
@@ -1,0 +1,6 @@
+@media (max-width: 800px) {
+  .jcc-switchboard__body {
+    display: none !important;
+  }
+}
+

--- a/web/themes/custom/atrium/templates/paragraph/paragraph--switchboard.html.twig
+++ b/web/themes/custom/atrium/templates/paragraph/paragraph--switchboard.html.twig
@@ -1,5 +1,9 @@
 {{ attach_library('atrium/switchboard_overrides') }}
 
+{% set rendered_body = paragraph.field_body|view|render %}
+{% set has_image = rendered_body matches('/<img[^>]*>/') %}
+
+<div class="paragraph-switchboard-wrapper{% if has_image %} has-image{% endif %}">
 {# To get a correct langcode, use a field that is translated since this paragraph
 is not translated itself (see https://www.drupal.org/node/2735121) #}
 {% set lang_code = paragraph.field_body.langcode %}
@@ -61,3 +65,6 @@ is not translated itself (see https://www.drupal.org/node/2735121) #}
     }
   } only %}
 {% endif %}
+
+</div>
+

--- a/web/themes/custom/atrium/templates/paragraph/paragraph--switchboard.html.twig
+++ b/web/themes/custom/atrium/templates/paragraph/paragraph--switchboard.html.twig
@@ -1,3 +1,5 @@
+{{ attach_library('atrium/switchboard_overrides') }}
+
 {# To get a correct langcode, use a field that is translated since this paragraph
 is not translated itself (see https://www.drupal.org/node/2735121) #}
 {% set lang_code = paragraph.field_body.langcode %}


### PR DESCRIPTION
Hi Ivan, this one works by placing the styling to a separate scss file. 